### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -4,6 +4,8 @@ on: [push]
 
 jobs:
     ci:
+        permissions:
+            contents: read
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/yuceltoluyag/yuceltoluyag.github.io/security/code-scanning/1](https://github.com/yuceltoluyag/yuceltoluyag.github.io/security/code-scanning/1)

To address this issue, add an explicit `permissions` block to the `ci` job to restrict the `GITHUB_TOKEN` to only the permissions it needs. For a job that only checks out code and builds dependencies, `contents: read` is almost always sufficient, as it allows the job to fetch repository contents but not to write or modify anything.

The edit should go in `.github/workflows/run-ci.yml`. Insert the following under the `ci:` job definition, before `runs-on: ubuntu-latest`:
```yaml
      permissions:
        contents: read
```
No other permissions are required since the job does not interact with, for example, issues or pull requests.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
