### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/_assets/js/search.js
+++ b/_assets/js/search.js
@@ -96,7 +96,8 @@ function displayResults(results, query) {
     searchResults.innerHTML = "";
 
     if (results.length === 0) {
-        searchResults.innerHTML = `<p class="search-no-results">"${query}" için sonuç bulunamadı</p>`;
+        const safeQuery = escapeHTML(query);
+        searchResults.innerHTML = `<p class="search-no-results">"${safeQuery}" için sonuç bulunamadı</p>`;
         return;
     }
 
@@ -164,6 +165,16 @@ function highlightText(text, query) {
 // Regex için özel karakterleri escape et
 function escapeRegExp(string) {
     return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// HTML meta-karakterleri için escaping
+function escapeHTML(str) {
+    return String(str)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
 }
 
 // Olay dinleyicileri


### PR DESCRIPTION
Potential fix for [https://github.com/yuceltoluyag/yuceltoluyag.github.io/security/code-scanning/2](https://github.com/yuceltoluyag/yuceltoluyag.github.io/security/code-scanning/2)

To fix the issue, we need to ensure that any user input (in this case, the search query) is properly escaped before being interpolated into HTML with `innerHTML`. The best way is to escape any HTML meta-characters in the search query before placing it in the DOM. This can be achieved by using a helper function to encode characters like `<`, `>`, `&`, and `"` to their corresponding HTML entities (e.g., `&lt;`, `&gt;`, etc.). Specifically, before displaying the search query inside the `innerHTML` assignment on line 99, we should escape the query string. This requires the addition of a function to encode the query and usage of that function in the template string.

Required changes in _assets/js/search.js:

- Add a helper function to escape HTML meta-characters.
- In `displayResults`, use this helper function on `query` before inserting it into `innerHTML`.
- Ensure the fix is only for this usage (line 99), as other usages (e.g., highlighting matches) may need different handling.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
