### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/themes/Minel/_assets/js/search.js
+++ b/themes/Minel/_assets/js/search.js
@@ -2,6 +2,18 @@
  * Arama fonksiyonalitesi
  */
 
+
+// HTML escaping utility to prevent XSS
+function escapeHTML(str) {
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/\//g, '&#x2F;');
+}
+
 // Arama verileri ve index için global değişkenler
 let searchData = [];
 let searchIndex = null;
@@ -138,7 +150,7 @@ function displayResults(results, query) {
     searchResults.innerHTML = "";
 
     if (results.length === 0) {
-        searchResults.innerHTML = `<p class="text-center text-base-content/60 py-8">"${query}" için sonuç bulunamadı</p>`;
+        searchResults.innerHTML = `<p class="text-center text-base-content/60 py-8">"${escapeHTML(query)}" için sonuç bulunamadı</p>`;
         return;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/yuceltoluyag/yuceltoluyag.github.io/security/code-scanning/3](https://github.com/yuceltoluyag/yuceltoluyag.github.io/security/code-scanning/3)

To fix the vulnerability, we need to ensure that untrusted user input (the `query` parameter) is never inserted into the DOM as HTML without proper escaping or sanitization. The best way to achieve this without affecting any existing search functionality is to escape the query string for HTML meta-characters before interpolating it into the template used for the search results message. This can be done by replacing instances of `&`, `<`, `>`, `"`, `'`, and `/` with their respective HTML entities. 

The proper place for this fix is at the sink, where the template string including the query is being composed for `.innerHTML` (line 141 in `displayResults`). We should add a utility function to escape HTML (e.g., `escapeHTML`) at the top of the JS file or just above the affected code block, and call it on `query` before it is interpolated: i.e., use `"${escapeHTML(query)}"` instead of `"${query}"` in the string assigned to `.innerHTML`. No other code needs modification, as only the output of the query is vulnerable here.

No external dependencies are needed; a small utility function (often a one-liner) is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
