### PR TITLE
Potential fix for code scanning alert no. 5: Client-side cross-site scripting

### DIFF
--- a/_assets/js/webmention-test.js
+++ b/_assets/js/webmention-test.js
@@ -66,11 +66,17 @@
         const urlInfo = document.createElement("div");
         urlInfo.style.cssText = "margin-bottom: 15px; font-size: 13px; color: #718096;";
         if (window.location.href.includes("localhost")) {
-            urlInfo.innerHTML = `
-                <strong style="color: #4a5568;">Not:</strong> Localhost ortamında test yapıyorsunuz. 
-                URL otomatik olarak production adresine çevrildi. Production URL: 
-                <span style="color: #2b6cb0;">${formatTestUrl(window.location.href)}</span>
-            `;
+            // Güvenli XSS önleme: innerHTML yerine textContent + element construction
+            // Not label
+            const strong = document.createElement("strong");
+            strong.style.color = "#4a5568";
+            strong.textContent = "Not:";
+            urlInfo.appendChild(strong);
+            urlInfo.appendChild(document.createTextNode(" Localhost ortamında test yapıyorsunuz. URL otomatik olarak production adresine çevrildi. Production URL: "));
+            const prodUrlSpan = document.createElement("span");
+            prodUrlSpan.style.color = "#2b6cb0";
+            prodUrlSpan.textContent = formatTestUrl(window.location.href);
+            urlInfo.appendChild(prodUrlSpan);
         }
         inputWrapper.appendChild(urlInfo);
 


### PR DESCRIPTION
Potential fix for [https://github.com/yuceltoluyag/yuceltoluyag.github.io/security/code-scanning/5](https://github.com/yuceltoluyag/yuceltoluyag.github.io/security/code-scanning/5)

To fix this DOM-based XSS, any user-controlled value written to HTML must be safely encoded before insertion. Specifically, on line 69, instead of interpolating the possibly dangerous string directly into `innerHTML` via template literals, we should use careful contextual encoding.

The best-practice approach is:
- Never assign unsanitized input via `innerHTML` (or similar sinks).
- Instead, create a child element (`span`), set its `textContent` property to the value (this inherently escapes any HTML), and append it to the DOM.
- If rich HTML structure is needed, build the HTML content with document methods and `.textContent` for any dynamic input.

For this case:
- Refactor the block conditioned on `window.location.href.includes("localhost")` (lines 68-74), so that instead of building the full string via template literal, you build the HTML elements and safely set the dynamic URL using `.textContent` (or `.innerText`).

This will require adjusting code in `_assets/js/webmention-test.js`, in the `createTestUI` function, specifically the handling of `urlInfo` within the relevant block.

No new methods or imports are needed; all can be achieved with standard DOM APIs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
