### PR TITLE
fix(webmentions): Handle undefined content and hide reposts

### DIFF
--- a/themes/baba/static/js/webmentions.js
+++ b/themes/baba/static/js/webmentions.js
@@ -29,9 +29,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     case "in-reply-to":
                         comments.push(mention);
                         break;
-                    case "repost-of":
-                        comments.push(mention); // Add reposts to comments section
-                        break;
+
                     case "mention-of":
                         comments.push(mention); // Add mentions to comments section
                         break;
@@ -115,7 +113,7 @@ document.addEventListener("DOMContentLoaded", () => {
                         </span>
                     </div>
                     <div class="webmention__content">
-                        ${mention.content.html || mention.content.text}
+                        ${(mention.content && (mention.content.html || mention.content.text)) || ''}
                     </div>
                 </div>
             `;


### PR DESCRIPTION
- In `webmentions.js`, added a check for `mention.content` to prevent a TypeError when it is undefined.
- Removed the `repost-of` case from the switch statement to hide reposts from the webmentions section.