### PR TITLE
fix: Resolve webfinger 404 for Bridgy Fed

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -33,7 +33,7 @@ PATH = "content"
 ARTICLE_PATHS = ["articles"]
 PAGE_PATHS = ["pages"]
 OUTPUT_PATH = "output"
-STATIC_PATHS = ["images", "extra", "files", ".well-known"]
+STATIC_PATHS = ["images", "extra", "files", "well-known"]
 EXTRA_PATH_METADATA = {
     "extra/robots.txt": {"path": "robots.txt", "template": True},
     "extra/humans.txt": {"path": "humans.txt", "template": True},
@@ -48,7 +48,7 @@ EXTRA_PATH_METADATA = {
         "path": "acf21962677a48049a6a234640504902.txt"
     },
     "extra/CNAME": {"path": "CNAME"},
-    ".well-known/webfinger": {"path": ".well-known/webfinger"},
+    "well-known/webfinger": {"path": ".well-known/webfinger"},
 }
 
 # =============================================================================


### PR DESCRIPTION
Adjusted Pelican configuration to correctly serve the `webfinger` file, addressing the 404 error encountered by Bridgy Fed.
- Moved `content/.well-known/webfinger` to `content/well-known/webfinger`.
- Updated `pelicanconf.py` to map `well-known/webfinger` to `output/.well-known/webfinger` in `STATIC_PATHS` and `EXTRA_PATH_METADATA`. This ensures the file is accessible for Fediverse and Bluesky integration.