### PR TITLE
fix: Use JS redirect to preserve query params for Bridgy Fed

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -362,6 +362,8 @@ HOME_HIDE_TAGS = True
 # REDIRECTS
 # =============================================================================
 REDIRECTS = {
+    "/.well-known/host-meta": "https://fed.brid.gy/.well-known/host-meta",
+    "/.well-known/webfinger": "https://fed.brid.gy/.well-known/webfinger",
     "/tags/facebook.html": "/etiket/facebook/",
     "/tags/facebook": "/etiket/facebook/",
     "/tags/github.html": "/etiket/github/",

--- a/themes/baba/templates/redirect.html
+++ b/themes/baba/templates/redirect.html
@@ -4,7 +4,9 @@
     <meta charset="utf-8">
     <title>Redirecting...</title>
     <link rel="canonical" href="{{ page.location }}" />
-    <meta http-equiv="refresh" content="{{ page.delay }}; URL={{ page.location }}" />
+    <script>
+        window.location.replace("{{ page.location }}" + window.location.search);
+    </script>
 </head>
 <body>
     <p>You are being redirected to <a href="{{ page.location }}">{{ page.title }}</a></p>


### PR DESCRIPTION
Updated the redirect mechanism to correctly handle Bridgy Fed integration.
- Modified the redirect template in the 'baba' theme to use JavaScript for redirects, ensuring query parameters are preserved.
- Configured the necessary redirects for /.well-known/webfinger and /.well-known/host-meta in pelicanconf.py using the REDIRECTS dictionary. This resolves the 'Missing required parameter' error from Bridgy Fed and the file download issue with host-meta.