### PR TITLE
fix: Bridgy Fediverse yapılandırmasını güncelle

### DIFF
--- a/content/extra/.well-known/host-meta
+++ b/content/extra/.well-known/host-meta
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <XRD xmlns='http://docs.oasis-open.org/ns/xri/xrd-1.0'>
-  <Link rel='lrdd' type='application/xrd+xml' template='https://brid.gy/webfinger?q={uri}'/>
+  <Link rel='lrdd' type='application/json'
+        template='https://fed.brid.gy/.well-known/webfinger?resource={uri}' />
 </XRD>

--- a/content/extra/.well-known/webfinger
+++ b/content/extra/.well-known/webfinger
@@ -58,5 +58,5 @@
       "template": "https://fed.brid.gy/web/yuceltoluyag.github.io?url={uri}"
     }
   ],
-  "subject": "acct:yuceltoluyag.github.io@web.brid.gy"
+  "subject": "acct:yuceltoluyag.github.io@yuceltoluyag.github.io"
 }


### PR DESCRIPTION
- 'host-meta' dosyası, webfinger aramaları için doğru 'fed.brid.gy' uç noktasını kullanacak şekilde güncellendi.
- 'webfinger' dosyasındaki 'subject' (konu), yerel alan adını kullanacak şekilde düzeltildi.