### PR TITLE
feat: Add atproto-did for Bluesky identity verification

### DIFF
--- a/content/extra/.well-known/atproto-did
+++ b/content/extra/.well-known/atproto-did
@@ -1,0 +1,1 @@
+did:plc:lu4xdq66ovwpakyavsmdvqbc

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -58,6 +58,9 @@ EXTRA_PATH_METADATA = {
     "extra/.well-known/host-meta": {
         "path": ".well-known/host-meta",
     },
+    "extra/.well-known/atproto-did": {
+        "path": ".well-known/atproto-did",
+    },
 }
 
 # =============================================================================


### PR DESCRIPTION
- Adds the `.well-known/atproto-did` file to establish the site's identity on the Bluesky social network.
- Updates `pelicanconf.py` to ensure the `atproto-did` file is correctly placed in the output directory.